### PR TITLE
feat: SOCKS5 прокси для бота, возможность локального билда

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ docker compose pull && docker compose up -d
 
 ## Сборка из исходников
 
+Для запуска всей связки через Docker Compose из текущего checkout:
+
+```bash
+cp docker-compose.example.yml docker-compose.yml
+# Заполни BOT_TOKEN/BOT_ADMIN_IDS и остальные нужные параметры в docker-compose.yml.
+docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+```
+
+Файл `docker-compose.build.yml` переопределяет только образ `statuspage`: Compose
+собирает его из локального `Dockerfile`, присваивает тег
+`xray-checker-statuspage:${VERSION:-local}` и оставляет конфигурацию
+`xray-checker`, host-сеть и том данных из основного compose-файла без изменений.
+При необходимости версию можно передать перед командой, например
+`VERSION=dev docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build`.
+
+Сборка одного бинарника без Docker:
+
 ```bash
 CGO_ENABLED=0 go build -trimpath -o statuspage ./cmd/statuspage
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ services:
     environment:
       # --- обязательное ---
       BOT_TOKEN: "ВПИШИ_ТОКЕН_БОТА"        # от @BotFather; "" = только страница, без бота
+      # TELEGRAM_PROXY: "socks5://user:password@127.0.0.1:1080" # (необяз.) SOCKS5 только для Telegram Bot API
       BOT_ADMIN_IDS: "ВПИШИ_СВОЙ_CHAT_ID"  # твой id от @userinfobot; несколько — через запятую
       # NOTIFY_CHAT_IDS: "-1001234567890"  # (необяз.) чаты/группы/каналы; топик форума — через двоеточие: -1001234567890:42 (прав на бота не дают)
       # --- базовое ---
@@ -73,6 +74,12 @@ volumes:
 алерты и ежедневную сводку помимо админов (управлять ботом они не могут). Для топика
 форума добавь его id через двоеточие: `-1001234567890:42`.
 Подписку и домен задаёшь в боте, в env их писать не нужно.
+
+Если Telegram недоступен напрямую, укажи `TELEGRAM_PROXY` в формате
+`socks5://host:port` или `socks5://user:password@host:port` и пересоздай контейнер
+`statuspage`. Прокси применяется только к Telegram Bot API; checker, подписки и
+загрузка обновлений продолжают работать напрямую. Спецсимволы в логине и пароле
+нужно URL-кодировать.
 
 > Если xray-checker уже поднят отдельно — убери его блок, а у `statuspage` укажи
 > `CHECKER_URL` на существующий чекер.
@@ -185,6 +192,7 @@ TLS — обычным `certbot --nginx -d status.example.com`.
 | Переменная | По умолчанию | Назначение |
 | --- | --- | --- |
 | `BOT_TOKEN` | — | Токен бота от @BotFather (пусто — только страница) |
+| `TELEGRAM_PROXY` | — | SOCKS5-прокси Telegram: `socks5://[user:password@]host:port` |
 | `BOT_ADMIN_IDS` | — | Chat id админов через запятую |
 | `NOTIFY_CHAT_IDS` | — | Чаты/группы/каналы для алертов; топик форума — `chatID:threadID` (прав на управление не дают) |
 | `CHECKER_URL` | `http://xray-checker:2112` | Адрес xray-checker (в host-сети — `http://localhost:2112`) |

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,10 @@
+# Overlay для локальной сборки statuspage из текущего checkout.
+# Использование: docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+services:
+  statuspage:
+    image: xray-checker-statuspage:${VERSION:-local}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION:-local}

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,6 +18,7 @@ services:
     environment:
       # --- обязательное ---
       BOT_TOKEN: ""                        # от @BotFather; "" = только страница, без бота
+      # TELEGRAM_PROXY: "socks5://user:password@127.0.0.1:1080" # (необяз.) SOCKS5 только для Telegram Bot API
       BOT_ADMIN_IDS: ""                    # твой id от @userinfobot; несколько — через запятую
       NOTIFY_CHAT_IDS: ""                  # чаты/группы/каналы для алертов: -1001234567890 или с топиком форума -1001234567890:42; неск. через запятую. Прав на бота не дают
       # --- базовое ---

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-telegram/bot v1.22.0
 	github.com/lib/pq v1.12.3
 	golang.org/x/crypto v0.54.0
+	golang.org/x/net v0.56.0
 	modernc.org/sqlite v1.54.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	modernc.org/libc v1.74.1 // indirect

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -95,7 +95,15 @@ func New(cfg config.Config, st *store.Store) (*Bot, error) {
 	}
 	tb := &Bot{st: st, cfg: cfg, admins: admins, alertTargets: alertTargets, lastDown: map[string]bool{},
 		upd: updater.New(cfg.UpdateURL, cfg.UpdateSHA256URL)}
-	b, err := bot.New(cfg.BotToken, bot.WithDefaultHandler(tb.onUpdate))
+	options := []bot.Option{bot.WithDefaultHandler(tb.onUpdate)}
+	if cfg.TelegramProxy != "" {
+		client, err := newTelegramHTTPClient(cfg.TelegramProxy)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, bot.WithHTTPClient(telegramPollTimeout, client))
+	}
+	b, err := bot.New(cfg.BotToken, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +116,7 @@ func (tb *Bot) Run(ctx context.Context) {
 	if tb == nil || tb.b == nil {
 		return
 	}
-	slog.Info("telegram bot started", "admins", len(tb.admins))
+	slog.Info("telegram bot started", "admins", len(tb.admins), "socks5_proxy", tb.cfg.TelegramProxy != "")
 	if len(tb.admins) == 0 {
 		slog.Warn("BOT_ADMIN_IDS пуст — бот не примет ни одной команды; впиши свой chat_id (@userinfobot)")
 	}

--- a/internal/bot/proxy.go
+++ b/internal/bot/proxy.go
@@ -1,0 +1,47 @@
+package bot
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	xproxy "golang.org/x/net/proxy"
+)
+
+const telegramPollTimeout = time.Minute
+
+// newTelegramHTTPClient ограничивает прокси только Telegram Bot API. Клиенты
+// чекера, подписок и обновлений продолжают ходить напрямую.
+func newTelegramHTTPClient(rawURL string) (*http.Client, error) {
+	proxyURL, err := url.Parse(rawURL)
+	if err != nil {
+		// Ошибки url.Parse могут содержать исходную строку вместе с паролем.
+		return nil, errors.New("TELEGRAM_PROXY содержит некорректный URL")
+	}
+	if proxyURL.Scheme != "socks5" && proxyURL.Scheme != "socks5h" {
+		return nil, errors.New("TELEGRAM_PROXY должен использовать схему socks5:// или socks5h://")
+	}
+	if proxyURL.Hostname() == "" {
+		return nil, errors.New("TELEGRAM_PROXY должен содержать адрес прокси")
+	}
+	if proxyURL.Path != "" || proxyURL.RawQuery != "" || proxyURL.Fragment != "" {
+		return nil, errors.New("TELEGRAM_PROXY не должен содержать путь, параметры или fragment")
+	}
+
+	forward := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	dialer, err := xproxy.FromURL(proxyURL, forward)
+	if err != nil {
+		return nil, errors.New("не удалось настроить TELEGRAM_PROXY")
+	}
+	contextDialer, ok := dialer.(xproxy.ContextDialer)
+	if !ok {
+		return nil, errors.New("TELEGRAM_PROXY не поддерживает отмену соединений")
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = contextDialer.DialContext
+	return &http.Client{Transport: transport, Timeout: telegramPollTimeout}, nil
+}

--- a/internal/bot/proxy_test.go
+++ b/internal/bot/proxy_test.go
@@ -1,0 +1,62 @@
+package bot
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTelegramHTTPClientRejectsInvalidProxy(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://127.0.0.1:1080",
+		"socks5://",
+		"socks5://127.0.0.1:1080/path",
+		"socks5://127.0.0.1:bad",
+	} {
+		if _, err := newTelegramHTTPClient(rawURL); err == nil {
+			t.Errorf("newTelegramHTTPClient(%q) succeeded", rawURL)
+		}
+	}
+}
+
+func TestTelegramHTTPClientUsesSOCKS5(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	connected := make(chan struct{}, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+		header := make([]byte, 2)
+		if _, readErr := io.ReadFull(conn, header); readErr != nil || header[0] != 5 {
+			return
+		}
+		methods := make([]byte, int(header[1]))
+		if _, readErr := io.ReadFull(conn, methods); readErr != nil {
+			return
+		}
+		connected <- struct{}{}
+		_, _ = conn.Write([]byte{5, 0})
+	}()
+
+	client, err := newTelegramHTTPClient("socks5://" + listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = client.Get("https://api.telegram.org")
+
+	select {
+	case <-connected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HTTP client did not connect to the SOCKS5 proxy")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	// Bootstrap для будущих фаз (бот/контроль). Парсим заранее, чтобы
 	// docker-compose уже был стабильным; в M0/M1 не используются.
 	BotToken      string
+	TelegramProxy string
 	BotAdminIDs   []int64
 	NotifyTargets []NotifyTarget
 	SecretKey     string
@@ -163,6 +164,7 @@ func Load() Config {
 		GlobalOutageRatio: atof("GLOBAL_OUTAGE_RATIO", 1.0),
 
 		BotToken:      getenv("BOT_TOKEN", ""),
+		TelegramProxy: getenv("TELEGRAM_PROXY", ""),
 		BotAdminIDs:   splitInt64("BOT_ADMIN_IDS"),
 		NotifyTargets: parseNotifyTargets("NOTIFY_CHAT_IDS"),
 		SecretKey:     getenv("SECRET_KEY", ""),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,3 +32,10 @@ func TestTLSDefaults(t *testing.T) {
 		t.Fatalf("tls defaults not empty: %q %q %q", c.TLSMode, c.CertFile, c.KeyFile)
 	}
 }
+
+func TestTelegramProxy(t *testing.T) {
+	t.Setenv("TELEGRAM_PROXY", "socks5://user:pass@127.0.0.1:1080")
+	if got := Load().TelegramProxy; got != "socks5://user:pass@127.0.0.1:1080" {
+		t.Fatalf("unexpected TelegramProxy: %q", got)
+	}
+}


### PR DESCRIPTION
## Что изменено

- Добавлена переменная окружения `TELEGRAM_PROXY` для подключения к Telegram Bot API через SOCKS5-прокси.
- Поддерживаются адреса:
  - `socks5://host:port`
  - `socks5h://host:port`
  - `socks5://user:password@host:port`
- Прокси применяется ко всем операциям Telegram-бота, включая long polling, отправку, редактирование и удаление сообщений.
- Остальные HTTP-клиенты приложения — checker, подписки и загрузка обновлений — продолжают работать напрямую.
- Добавлена проверка URL прокси. Ошибки конфигурации не раскрывают логин или пароль.
- При отсутствии `TELEGRAM_PROXY` сохраняется прежнее прямое подключение.

## Docker Compose

Добавлен `docker-compose.build.yml`, позволяющий собирать `statuspage` из текущих исходников:

```bash
cp docker-compose.example.yml docker-compose.yml
docker compose \
  -f docker-compose.yml \
  -f docker-compose.build.yml \
  up -d --build